### PR TITLE
Fix README formatting: Remove extra space for correct command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The generated prompts will be in `Prompts-generated` by default.
 After getting the prompts, you can run the following command to generate the requirements:
 
 ```bash
-python gpt4.py --prompt-dir=Prompts/torch-inductor/src2req \ 
+python gpt4.py --prompt-dir=Prompts/torch-inductor/src2req \
     --outdir=Requirements/torch-inductor/req \
     --temperature=0.0 \
     --batch-size=1


### PR DESCRIPTION
This PR fixes a minor formatting issue in the README.md file, where an extra space in the bash code block caused incorrect command execution. Removing the space ensures that the command runs properly when copied and pasted.

